### PR TITLE
[Bug Fix] removed rkey from the implementation of MR

### DIFF
--- a/CQ.c
+++ b/CQ.c
@@ -3,8 +3,16 @@
 
 static int cq_counter = 0;
 
-void init_cq(CQ *cq, uint16_t sz) {
+void init_cq(CQ *cq, uint8_t sz) {
   cq->cq_num = cq_counter++;
   cq->queue = malloc(sizeof(circular_buffer));
   cb_init(cq->queue, sz, sizeof(CQE));
+}
+
+int cq_push_back(CQ *cq, CQE *cqe){
+    return cb_push_back(cq->queue, (void *)cqe);
+}
+
+int cq_pop_front(CQ *cq, CQE *cqe){
+    return cb_pop_front(cq->queue, (void *)cqe);
 }

--- a/CQ.h
+++ b/CQ.h
@@ -4,19 +4,24 @@
 #include "Queue.h"
 
 
-
-
 typedef struct cqe {
-  int offset;
-  int sz;
-  MR *mr;
+  uint8_t wr_id;
+  uint8_t byte_len;
+  uint8_t qp_num;
+  uint8_t remote_qp_num;
 } CQE;
 
 
-
 typedef struct cq {
-  int cq_num;
+  uint8_t cq_num;
   circular_buffer* queue;
 } CQ;
+
+
+void init_cq(CQ *cq, uint8_t sz);
+
+int cq_push_back(CQ *cq, CQE *cqe);
+
+int cq_pop_front(CQ *cq, CQE *cqe);
 
 #endif

--- a/MR.c
+++ b/MR.c
@@ -8,5 +8,4 @@ void init_mr(MR *mr, uint16_t sz){
   for (uint8_t i = 0; i < sz; i++) {
     *(mr->buffer+i) = 0;
   }
-  mr->rkey = 1;
 }

--- a/MR.h
+++ b/MR.h
@@ -8,7 +8,6 @@
 typedef struct mr {
   uint8_t* buffer;
   uint16_t sz;
-  uint8_t rkey;
 } MR;
 
 void init_mr(MR *mr, uint16_t sz);


### PR DESCRIPTION
Currently there will be no "RDMA" implementation so I have removed
the rkey value from the MR struct.

Signed-off-by: Amit Matityahu <amit2129@gmail.com>