### PR TITLE
[Bug Fix] Substituted 'microband' for $(TARGET) in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,12 @@ $(BUILD_DIR):
 $(BUILD_DIR)$(TARGET)_test: $(BUILD_DIR)
 	$(RM) $(BUILD_DIR)$(TARGET)_*
 	$(CC) $(CFLAGS) -DDEBUG -o $(BUILD_DIR)$(TARGET)_test $(BUILD_DIR)*.c
-	ln -sf $(BUILD_DIR)$(TARGET)_test microband
+	ln -sf $(BUILD_DIR)$(TARGET)_test $(TARGET)
 
 $(BUILD_DIR)$(TARGET)_run: $(BUILD_DIR)
 	$(RM) $(BUILD_DIR)$(TARGET)_*
 	$(CC) $(CFLAGS) -o $(BUILD_DIR)$(TARGET)_run $(BUILD_DIR)*.c
-	ln -sf $(BUILD_DIR)$(TARGET)_run microband
-
+	ln -sf $(BUILD_DIR)$(TARGET)_run $(TARGET)
 
 build_test: $(BUILD_DIR)$(TARGET)_test
 


### PR DESCRIPTION
Fixed makefile with substitution of hardcoded 'microband'
to $(TARGET).

Signed-off-by: Amit Matityahu <amit2129@gmail.com>