### PR TITLE
[Feature] Added locking to MR in read/write and Queue push/pop

### DIFF
--- a/common/src/queue.c
+++ b/common/src/queue.c
@@ -25,14 +25,16 @@ void cb_free(circular_buffer *cb)
 
 int cb_push_back(circular_buffer *cb, const void *item)
 {
-
+  // locking
+  pthread_mutex_lock(&cb->queue_lock);
   if (cb->count == cb->capacity) {
+    // unlocking
+    pthread_mutex_unlock(&cb->queue_lock);
     return 1;
   }
 
 
-  // locking
-  pthread_mutex_lock(&cb->queue_lock);
+  
 
   memcpy(cb->head, item, cb->sz);
   cb->head = (char*)cb->head + cb->sz;
@@ -49,7 +51,11 @@ int cb_push_back(circular_buffer *cb, const void *item)
 
 int cb_pop_front(circular_buffer *cb, void *item)
 {
+  // locking
+  pthread_mutex_lock(&cb->queue_lock);
   if (cb->count == 0) {
+    // unlocking
+    pthread_mutex_unlock(&cb->queue_lock);
     return 1;
   }
 

--- a/common/src/queue.c
+++ b/common/src/queue.c
@@ -25,15 +25,26 @@ void cb_free(circular_buffer *cb)
 
 int cb_push_back(circular_buffer *cb, const void *item)
 {
+
   if (cb->count == cb->capacity) {
     return 1;
   }
+
+
+  // locking
+  pthread_mutex_lock(&cb->queue_lock);
+
   memcpy(cb->head, item, cb->sz);
   cb->head = (char*)cb->head + cb->sz;
   if (cb->head == cb->buffer_end)
     cb->head = cb->buffer;
   cb->count++;
+
+  // unlocking
+  pthread_mutex_unlock(&cb->queue_lock);
+
   return 0;
+
 }
 
 int cb_pop_front(circular_buffer *cb, void *item)
@@ -41,11 +52,18 @@ int cb_pop_front(circular_buffer *cb, void *item)
   if (cb->count == 0) {
     return 1;
   }
+
+  // locking
+  pthread_mutex_lock(&cb->queue_lock);
+
   memcpy(item, cb->tail, cb->sz);
 
   cb->tail = (char*)cb->tail + cb->sz;
   if (cb->tail == cb->buffer_end)
     cb->tail = cb->buffer;
   cb->count--;
+
+  // unlocking
+  pthread_mutex_unlock(&cb->queue_lock);
   return 0;
 }

--- a/common/src/queue.h
+++ b/common/src/queue.h
@@ -2,6 +2,7 @@
 #define QUEUE_H
 
 #include <stdlib.h>
+#include <pthread.h>
 
 typedef struct circular_buffer
 {
@@ -12,6 +13,7 @@ typedef struct circular_buffer
     size_t sz;        // size of each item in the buffer
     void *head;       // pointer to head
     void *tail;       // pointer to tail
+	pthread_mutex_t queue_lock;
 } circular_buffer;
 
 void cb_init(circular_buffer *cb, size_t capacity, size_t sz);

--- a/infiniband/src/MR.c
+++ b/infiniband/src/MR.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include "MR.h"
 
-
 void init_mr(MR *mr, uint16_t sz){
   mr->sz = sz;
   mr->buffer = (uint8_t * )malloc(sz * sizeof(uint8_t));
@@ -20,3 +19,22 @@ void clear_mr(MR *mr) {
     *(mr->buffer+i) = 0;
   }
 }
+
+int write_to_mr(MR *mr, uint32_t offset, uint8_t *src_buffer, uint32_t length) {
+	if (offset + length > mr->sz)
+		return 1;
+
+	pthread_mutex_lock(&mr->rw_lock);
+	memcpy(mr->buffer + offset, src_buffer, length);
+	pthread_mutex_unlock(&mr->rw_lock);
+}
+
+int read_from_mr(MR *mr, uint32_t offset, uint8_t *dest_buffer, uint32_t length) {
+	if (offset + length > mr->sz)
+		return 1;
+
+	pthread_mutex_lock(&mr->rw_lock);
+	memcpy(dest_buffer, mr->buffer + offset, length);
+	pthread_mutex_unlock(&mr->rw_lock);
+}
+

--- a/infiniband/src/MR.h
+++ b/infiniband/src/MR.h
@@ -2,17 +2,23 @@
 #define MR_H
 
 #include "../../common/src/queue.h"
-
+#include <string.h>
 #include <stdint.h>
+#include <pthread.h>
 
 typedef struct mr {
   uint8_t* buffer;
   uint16_t sz;
+  pthread_mutex_t rw_lock;
 } MR;
 
 void init_mr(MR *mr, uint16_t sz);
 
 void free_mr(MR *mr);
+
+int write_to_mr(MR *mr, uint32_t offset, uint8_t *src_buffer, uint32_t length);
+
+int read_from_mr(MR *mr, uint32_t offset, uint8_t *dest_buffer, uint32_t length);
 
 
 #endif


### PR DESCRIPTION
Reading and writing from an MR is now thread safe.
pushing and popping objects from queues is now thread safe.

Signed-off-by: Amit Matityahu <amit2129@gmail.com>